### PR TITLE
Implement SysEx messages and SysEx communication

### DIFF
--- a/RtMidi.Core.Tests/Enums/KeyTests.cs
+++ b/RtMidi.Core.Tests/Enums/KeyTests.cs
@@ -13,7 +13,7 @@ namespace RtMidi.Core.Tests.Enums
         }
 
         [Fact]
-        public void SHould_Return_Empty_String_For_Undefined_Enum_Values()
+        public void Should_Return_Empty_String_For_Undefined_Enum_Values()
         {
             Assert.Equal(string.Empty, ((Key) 128).DisplayName());
         }

--- a/RtMidi.Core.Tests/Enums/NoteTests.cs
+++ b/RtMidi.Core.Tests/Enums/NoteTests.cs
@@ -13,7 +13,7 @@ namespace RtMidi.Core.Tests.Enums
         }
 
         [Fact]
-        public void SHould_Return_Empty_String_For_Undefined_Enum_Values()
+        public void Should_Return_Empty_String_For_Undefined_Enum_Values()
         {
             Assert.Equal(string.Empty, ((Note)12).DisplayName());
         }

--- a/RtMidi.Core/Devices/IMidiInputDevice.cs
+++ b/RtMidi.Core/Devices/IMidiInputDevice.cs
@@ -51,6 +51,11 @@ namespace RtMidi.Core.Devices
         /// </summary>
         /// <param name="mode">Mode</param>
         void SetNrpnMode(NrpnMode mode);
+
+        /// <summary>
+        /// SysEx data message event.
+        /// </summary>
+        event SysExMessageHandler SysEx;
     }
 
     public delegate void NoteOffMessageHandler(IMidiInputDevice sender, in NoteOffMessage msg);
@@ -68,4 +73,6 @@ namespace RtMidi.Core.Devices
     public delegate void PitchBendMessageHandler(IMidiInputDevice sender, in PitchBendMessage msg);
 
     public delegate void NrpnMessageHandler(IMidiInputDevice sender, in NrpnMessage msg);
+
+    public delegate void SysExMessageHandler(IMidiInputDevice sender, in SysExMessage msg);
 }

--- a/RtMidi.Core/Devices/IMidiOutputDevice.cs
+++ b/RtMidi.Core/Devices/IMidiOutputDevice.cs
@@ -59,5 +59,12 @@ namespace RtMidi.Core.Devices
         /// <param name="nrpnMessage"></param>
         /// <returns>True if sent, false otherwise</returns>
         bool Send(in NrpnMessage nrpnMessage);
+
+        /// <summary>
+        /// Send SysEx message
+        /// </summary>
+        /// <param name="sysExMessage"></param>
+        /// <returns>True if sent, false otherwise</returns>
+        bool Send(in SysExMessage sysExMessage);
     }
 }

--- a/RtMidi.Core/Devices/Midi.cs
+++ b/RtMidi.Core/Devices/Midi.cs
@@ -24,6 +24,9 @@
             internal const byte ProgramChangeBitmask = 0b1100_0000;
             internal const byte ChannelPressureBitmask = 0b1101_0000;
             internal const byte PitchBendChange = 0b1110_0000;
+            internal const byte System = 0b1111_0000;
+            internal const byte SysExStart = 0b1111_0000;
+            internal const byte SysExEnd = 0b1111_0111;
         }
     }
 }

--- a/RtMidi.Core/Devices/MidiInputDevice.cs
+++ b/RtMidi.Core/Devices/MidiInputDevice.cs
@@ -96,11 +96,21 @@ namespace RtMidi.Core.Devices
                     if (PitchBendMessage.TryDecode(message, out var pitchBendMessage))
                         PitchBend?.Invoke(this, in pitchBendMessage);
                     break;
+
                 case Midi.Status.System:
-                    if (status == Midi.Status.SysExStart)
-                        if (SysExMessage.TryDecode(message, out var sysexMessage))
-                            SysEx?.Invoke(this, in sysexMessage);
+                    switch (status)
+                    {
+                        case Midi.Status.SysExStart:
+                            if (SysExMessage.TryDecode(message, out var sysExMessage))
+                                SysEx?.Invoke(this, in sysExMessage);
+                            break;
+                        
+                        default:
+                            Log.Error("Unknown system message type {Status}", $"{status:X2}");
+                            break;
+                    }
                     break;
+                
                 default:
                     Log.Error("Unknown message type {Bitmask}", $"{status & 0b1111_0000:X2}");
                     break;

--- a/RtMidi.Core/Devices/MidiInputDevice.cs
+++ b/RtMidi.Core/Devices/MidiInputDevice.cs
@@ -35,6 +35,7 @@ namespace RtMidi.Core.Devices
         public event ChannelPressureMessageHandler ChannelPressure;
         public event PitchBendMessageHandler PitchBend;
         public event NrpnMessageHandler Nrpn;
+        public event SysExMessageHandler SysEx;
 
         private void RtMidiInputDevice_Message(object sender, byte[] message)
         {
@@ -95,6 +96,11 @@ namespace RtMidi.Core.Devices
                     if (PitchBendMessage.TryDecode(message, out var pitchBendMessage))
                         PitchBend?.Invoke(this, in pitchBendMessage);
                     break;
+                case Midi.Status.System:
+                    if (status == Midi.Status.SysExStart)
+                        if (SysExMessage.TryDecode(message, out var sysexMessage))
+                            SysEx?.Invoke(this, in sysexMessage);
+                    break;
                 default:
                     Log.Error("Unknown message type {Bitmask}", $"{status & 0b1111_0000:X2}");
                     break;
@@ -113,6 +119,7 @@ namespace RtMidi.Core.Devices
             ProgramChange = null;
             ChannelPressure = null;
             PitchBend = null;
+            SysEx = null;
         }
 
         private void OnControlChange(in ControlChangeMessage e)

--- a/RtMidi.Core/Devices/MidiInputDevice.cs
+++ b/RtMidi.Core/Devices/MidiInputDevice.cs
@@ -72,7 +72,7 @@ namespace RtMidi.Core.Devices
                         NoteOff?.Invoke(this, in noteOffMessage);
                     break;
                 case Midi.Status.NoteOnBitmask:
-                    if (NoteOnMessage.TryDecoce(message, out var noteOnMessage))
+                    if (NoteOnMessage.TryDecode(message, out var noteOnMessage))
                         NoteOn?.Invoke(this, in noteOnMessage);
                     break;
                 case Midi.Status.PolyphonicKeyPressureBitmask:

--- a/RtMidi.Core/Devices/MidiOutputDevice.cs
+++ b/RtMidi.Core/Devices/MidiOutputDevice.cs
@@ -36,5 +36,8 @@ namespace RtMidi.Core.Devices
 
         public bool Send(in NrpnMessage nrpnMessage)
             => nrpnMessage.Encode().All(msg => Send(in msg));
+        
+        public bool Send(in SysExMessage sysExMessage)
+            => _outputDevice.SendMessage(sysExMessage.Encode());
     }
 }

--- a/RtMidi.Core/Messages/NoteOnMessage.cs
+++ b/RtMidi.Core/Messages/NoteOnMessage.cs
@@ -44,7 +44,7 @@ namespace RtMidi.Core.Messages
             };
         }
 
-        internal static bool TryDecoce(byte[] message, out NoteOnMessage msg)
+        internal static bool TryDecode(byte[] message, out NoteOnMessage msg)
         {
             if (message.Length != 3)
             {

--- a/RtMidi.Core/Messages/StructHelper.cs
+++ b/RtMidi.Core/Messages/StructHelper.cs
@@ -18,17 +18,14 @@ namespace RtMidi.Core.Messages
                 throw new ArgumentOutOfRangeException(parameter, "Must be within 0-16383");
         }
 
-        public static void IsValidSysEx(byte[] data) {
-            if (data[0] != Midi.Status.SysExStart)
-                throw new ArgumentException($"SysEx message start byte must be {Midi.Status.SysExStart}");
-
-            for (int i = 1; i < data.Length - 1; i++) {
+        public static byte[] IsValidSysEx(byte[] data) {
+            for (int i = 1; i < data.Length - 1; i++)
+            {
                 if (data[i] == Midi.Status.SysExStart || data[i] == Midi.Status.SysExEnd)
                     throw new ArgumentException($"SysEx message data byte must not be {Midi.Status.SysExStart} or {Midi.Status.SysExEnd}");
             }
 
-            if (data[data.Length - 1] != Midi.Status.SysExEnd)
-                throw new ArgumentException($"SysEx message end byte must be {Midi.Status.SysExEnd}");
+            return data;
         }
 
         public static byte StatusByte(byte statusBitmask, Channel channel)
@@ -39,5 +36,29 @@ namespace RtMidi.Core.Messages
 
         public static byte DataByte(Key key)
             => (byte)(Midi.DataBitmask & (int)key);
+        
+        public static byte[] StripSysEx(byte[] data) {
+            byte[] stripped = new byte[data.Length - 2];
+            
+            for (int i = 1; i < data.Length - 1; i++)
+            {
+                stripped[i - 1] = data[i];
+            }
+
+            return stripped;
+        }
+
+        public static byte[] FormatSysEx(byte[] data) {
+            byte[] appended = new byte[data.Length + 2];
+            
+            appended[0] = Midi.Status.SysExStart;
+            for (int i = 0; i < data.Length; i++)
+            {
+                appended[i + 1] = data[i];
+            }
+            appended[appended.Length - 1] = Midi.Status.SysExEnd;
+
+            return appended;
+        }
     }
 }

--- a/RtMidi.Core/Messages/StructHelper.cs
+++ b/RtMidi.Core/Messages/StructHelper.cs
@@ -18,6 +18,19 @@ namespace RtMidi.Core.Messages
                 throw new ArgumentOutOfRangeException(parameter, "Must be within 0-16383");
         }
 
+        public static void IsValidSysEx(byte[] data) {
+            if (data[0] != Midi.Status.SysExStart)
+                throw new ArgumentException($"SysEx message start byte must be {Midi.Status.SysExStart}");
+
+            for (int i = 1; i < data.Length - 1; i++) {
+                if (data[i] == Midi.Status.SysExStart || data[i] == Midi.Status.SysExEnd)
+                    throw new ArgumentException($"SysEx message data byte must not be {Midi.Status.SysExStart} or {Midi.Status.SysExEnd}");
+            }
+
+            if (data[data.Length - 1] != Midi.Status.SysExEnd)
+                throw new ArgumentException($"SysEx message end byte must be {Midi.Status.SysExEnd}");
+        }
+
         public static byte StatusByte(byte statusBitmask, Channel channel)
             => (byte)(statusBitmask | (Midi.ChannelBitmask & (int)channel));
 

--- a/RtMidi.Core/Messages/SysExMessage.cs
+++ b/RtMidi.Core/Messages/SysExMessage.cs
@@ -12,9 +12,7 @@ namespace RtMidi.Core.Messages
 
         public SysExMessage(byte[] data)
         {
-            StructHelper.IsValidSysEx(data);
-
-            Data = data;
+            Data = StructHelper.IsValidSysEx(data);
         }
 
         /// <summary>
@@ -24,7 +22,7 @@ namespace RtMidi.Core.Messages
 
         internal byte[] Encode()
         {
-            return Data;
+            return StructHelper.FormatSysEx(Data);
         }
 
         internal static bool TryDecode(byte[] message, out SysExMessage msg)
@@ -36,7 +34,8 @@ namespace RtMidi.Core.Messages
                 return false;
             }
 
-            if (message[0] != Midi.Status.SysExStart || message[message.Length - 1] != Midi.Status.SysExEnd) {
+            if (message[0] != Midi.Status.SysExStart || message[message.Length - 1] != Midi.Status.SysExEnd)
+            {
                 Log.Error("Not a valid SysEx message received for SysEx message", message.Length);
                 msg = default;
                 return false;
@@ -44,7 +43,7 @@ namespace RtMidi.Core.Messages
 
             msg = new SysExMessage
             (
-                message
+                StructHelper.StripSysEx(message)
             );
             return true;
         }

--- a/RtMidi.Core/Messages/SysExMessage.cs
+++ b/RtMidi.Core/Messages/SysExMessage.cs
@@ -1,0 +1,57 @@
+﻿using RtMidi.Core.Enums;
+using Serilog;
+using RtMidi.Core.Devices;
+namespace RtMidi.Core.Messages
+{
+    /// <summary>
+    /// This message contains System Exclusive raw data sent from the device to the host.
+    /// </summary>
+    public readonly struct SysExMessage
+    {
+        private static readonly ILogger Log = Serilog.Log.ForContext<SysExMessage>();
+
+        public SysExMessage(byte[] data)
+        {
+            StructHelper.IsValidSysEx(data);
+
+            Data = data;
+        }
+
+        /// <summary>
+        /// SysEx Data Array
+        /// </summary>
+        public byte[] Data { get; }
+
+        internal byte[] Encode()
+        {
+            return Data;
+        }
+
+        internal static bool TryDecode(byte[] message, out SysExMessage msg)
+        {
+            if (message.Length <= 1)
+            {
+                Log.Error("Incorrect number of bytes ({Length}) received for SysEx message", message.Length);
+                msg = default;
+                return false;
+            }
+
+            if (message[0] != Midi.Status.SysExStart || message[message.Length - 1] != Midi.Status.SysExEnd) {
+                Log.Error("Not a valid SysEx message received for SysEx message", message.Length);
+                msg = default;
+                return false;
+            }
+
+            msg = new SysExMessage
+            (
+                message
+            );
+            return true;
+        }
+
+        public override string ToString()
+        {
+            return $"{nameof(Data)}: {string.Join(", ", Data)}";
+        }
+    }
+}

--- a/RtMidi.Core/RtMidi.Core.csproj
+++ b/RtMidi.Core/RtMidi.Core.csproj
@@ -39,9 +39,13 @@
     <Folder Include="Unmanaged\" />
     <Folder Include="Unmanaged\API\" />
     <Folder Include="Unmanaged\Devices\" />
-    <Folder Include="Devices\Infos\" />
     <Folder Include="Unmanaged\Devices\Infos\" />
+    <Folder Include="Devices\" />
+    <Folder Include="Devices\Infos\" />
     <Folder Include="Devices\Nrpn\" />
+    <Folder Include="Enums\" />
+    <Folder Include="Enums\Core" />
+    <Folder Include="Messages\" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Serilog" Version="2.6.0" />


### PR DESCRIPTION
Because this functionality is needed for my own project which uses this library, I've decided to contribute and implement SysEx communication. Luckily, the library is extremely well written, so this wasn't too hard of a task to achieve on its own. Hopefully lots of users can benefit from this functionality.

Works as expected from manual testing. I am not sure as to how I should implement actual Tests though, as I see for other messages all possible values are tested but this is not so feasible for a SysEx message which can contain an arbitrary amount of data. I'm looking for feedback on how to proceed with those. This is not ready to merge until proper Tests are written.

Oh, and I also encountered a small typo ("TryDecoce" instead of "TryDecode") while observing how NoteOnMessages worked, which I corrected as well.