### PR TITLE
RtMidiInputDevice: don't ignore SysEx

### DIFF
--- a/RtMidi.Core/Unmanaged/Devices/RtMidiInputDevice.cs
+++ b/RtMidi.Core/Unmanaged/Devices/RtMidiInputDevice.cs
@@ -27,6 +27,10 @@ namespace RtMidi.Core.Unmanaged.Devices
                 handle = RtMidiC.Input.CreateDefault();
                 CheckForError(handle);
 
+                Log.Debug("Setting types to ignore");
+                RtMidiC.Input.IgnoreTypes(handle, false, true, true);
+                CheckForError(handle);
+
                 Log.Debug("Setting input callback");
                 RtMidiC.Input.SetCallback(handle, _rtMidiCallbackDelegate, IntPtr.Zero);
                 CheckForError(handle);


### PR DESCRIPTION
With this change, RtMidi is instructed not to ignore SysEx messages. This allows for SysEx input to function as intended. Resolves #16.