### PR TITLE
WIP: Timestamp & additional messages support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 # Changelog
 
-## 1.0.50
-* Pulled updates for `rtmidi` from [upstream](https://github.com/thestk/rtmidi)
-
 ## 1.0.49
 
 * Pulled updates for `rtmidi` from [upstream](https://github.com/thestk/rtmidi) and compiled new unmanaged binaries for

--- a/RtMidi.Core.Tests/RtMidiInputDeviceMock.cs
+++ b/RtMidi.Core.Tests/RtMidiInputDeviceMock.cs
@@ -7,9 +7,9 @@ namespace RtMidi.Core.Tests
     {
         public bool IsOpen => true;
 
-        public event EventHandler<byte[]> Message;
+        public event EventHandler<RtMidiReceivedEventArgs> Message;
 
-        public void OnMessage(byte[] message) => Message?.Invoke(this, message);
+        public void OnMessage(byte[] message) => Message?.Invoke(this, new RtMidiReceivedEventArgs(0, message));
 
         public void Close()
         {

--- a/RtMidi.Core/Devices/IMidiInputDevice.cs
+++ b/RtMidi.Core/Devices/IMidiInputDevice.cs
@@ -47,6 +47,31 @@ namespace RtMidi.Core.Devices
         event NrpnMessageHandler Nrpn;
 
         /// <summary>
+        /// Clock event
+        /// </summary>
+        event ClockMessageHandler Clock;
+
+        /// <summary>
+        /// Start event
+        /// </summary>
+        event StartMessageHandler Start;
+
+        /// <summary>
+        /// Stop event
+        /// </summary>
+        event StopMessageHandler Stop;
+
+        /// <summary>
+        /// Continue event
+        /// </summary>
+        event ContinueMessageHandler Continue;
+
+        /// <summary>
+        /// Song Position Pointer event
+        /// </summary>
+        event SongPositionPointerMessageHandler SongPositionPointer;
+        
+        /// <summary>
         /// Set NRPN interpretation mode
         /// </summary>
         /// <param name="mode">Mode</param>
@@ -75,4 +100,14 @@ namespace RtMidi.Core.Devices
     public delegate void NrpnMessageHandler(IMidiInputDevice sender, in NrpnMessage msg);
 
     public delegate void SysExMessageHandler(IMidiInputDevice sender, in SysExMessage msg);
+    
+    public delegate void ClockMessageHandler(IMidiInputDevice sender, in ClockMessage msg);
+    
+    public delegate void StartMessageHandler(IMidiInputDevice sender, in StartMessage msg);
+    
+    public delegate void StopMessageHandler(IMidiInputDevice sender, in StopMessage msg);
+    
+    public delegate void ContinueMessageHandler(IMidiInputDevice sender, in ContinueMessage msg);
+    
+    public delegate void SongPositionPointerMessageHandler(IMidiInputDevice sender, in SongPositionPointerMessage msg);
 }

--- a/RtMidi.Core/Devices/Midi.cs
+++ b/RtMidi.Core/Devices/Midi.cs
@@ -27,6 +27,12 @@
             internal const byte System = 0b1111_0000;
             internal const byte SysExStart = 0b1111_0000;
             internal const byte SysExEnd = 0b1111_0111;
+            internal const byte SongPositionPointer = 0b1111_0010;
+            internal const byte Clock = 0b1111_1000;
+            internal const byte Start = 0b1111_1010;
+            internal const byte Continue = 0b1111_1011;
+            internal const byte Stop = 0b1111_1100;
+            
         }
     }
 }

--- a/RtMidi.Core/Devices/MidiInputDevice.cs
+++ b/RtMidi.Core/Devices/MidiInputDevice.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using RtMidi.Core.Messages;
 using RtMidi.Core.Unmanaged.Devices;
 using Serilog;
@@ -36,16 +37,21 @@ namespace RtMidi.Core.Devices
         public event PitchBendMessageHandler PitchBend;
         public event NrpnMessageHandler Nrpn;
         public event SysExMessageHandler SysEx;
+        public event ClockMessageHandler Clock;
+        public event StartMessageHandler Start;
+        public event StopMessageHandler Stop;
+        public event ContinueMessageHandler Continue;
+        public event SongPositionPointerMessageHandler SongPositionPointer;
 
-        private void RtMidiInputDevice_Message(object sender, byte[] message)
+        private void RtMidiInputDevice_Message(object sender, RtMidiReceivedEventArgs message)
         {
-            if (message == null)
+            if (message.Data == null)
             {
                 Log.Error("Received null message from device");
                 return;
             }
 
-            if (message.Length == 0) 
+            if (message.Data.Length == 0) 
             {
                 Log.Error("Received empty message from device");
                 return;
@@ -63,37 +69,38 @@ namespace RtMidi.Core.Devices
             }
         }
 
-        private void Decode(byte[] message)
+        private void Decode(RtMidiReceivedEventArgs message)
         {
-            byte status = message[0];
+            var messageData = message.Data;
+            byte status = messageData[0];
             switch (status & 0b1111_0000)
             {
                 case Midi.Status.NoteOffBitmask:
-                    if (NoteOffMessage.TryDecode(message, out var noteOffMessage))
+                    if (NoteOffMessage.TryDecode(message.Timestamp, messageData, out var noteOffMessage))
                         NoteOff?.Invoke(this, in noteOffMessage);
                     break;
                 case Midi.Status.NoteOnBitmask:
-                    if (NoteOnMessage.TryDecode(message, out var noteOnMessage))
+                    if (NoteOnMessage.TryDecode(message.Timestamp, messageData, out var noteOnMessage))
                         NoteOn?.Invoke(this, in noteOnMessage);
                     break;
                 case Midi.Status.PolyphonicKeyPressureBitmask:
-                    if (PolyphonicKeyPressureMessage.TryDecode(message, out var polyphonicKeyPressureMessage))
+                    if (PolyphonicKeyPressureMessage.TryDecode(message.Timestamp, messageData, out var polyphonicKeyPressureMessage))
                         PolyphonicKeyPressure?.Invoke(this, in polyphonicKeyPressureMessage);
                     break;
                 case Midi.Status.ControlChangeBitmask:
-                    if (ControlChangeMessage.TryDecode(message, out var controlChangeMessage))
+                    if (ControlChangeMessage.TryDecode(message.Timestamp, messageData, out var controlChangeMessage))
                         _nrpnInterpreters[(int)controlChangeMessage.Channel].HandleControlChangeMessage(in controlChangeMessage);
                     break;
                 case Midi.Status.ProgramChangeBitmask:
-                    if (ProgramChangeMessage.TryDecode(message, out var programChangeMessage))
+                    if (ProgramChangeMessage.TryDecode(message.Timestamp, messageData, out var programChangeMessage))
                         ProgramChange?.Invoke(this, in programChangeMessage);
                     break;
                 case Midi.Status.ChannelPressureBitmask:
-                    if (ChannelPressureMessage.TryDecode(message, out var channelPressureMessage))
+                    if (ChannelPressureMessage.TryDecode(message.Timestamp, messageData, out var channelPressureMessage))
                         ChannelPressure?.Invoke(this, in channelPressureMessage);
                     break;
                 case Midi.Status.PitchBendChange:
-                    if (PitchBendMessage.TryDecode(message, out var pitchBendMessage))
+                    if (PitchBendMessage.TryDecode(message.Timestamp, messageData, out var pitchBendMessage))
                         PitchBend?.Invoke(this, in pitchBendMessage);
                     break;
 
@@ -101,17 +108,34 @@ namespace RtMidi.Core.Devices
                     switch (status)
                     {
                         case Midi.Status.SysExStart:
-                            if (SysExMessage.TryDecode(message, out var sysExMessage))
+                            if (SysExMessage.TryDecode(message.Timestamp, messageData, out var sysExMessage))
                                 SysEx?.Invoke(this, in sysExMessage);
                             break;
-                        
+                        case Midi.Status.SongPositionPointer:
+                            if (SongPositionPointerMessage.TryDecode(message.Timestamp, messageData, out var songPositionPointerMessage))
+                                SongPositionPointer?.Invoke(this, in songPositionPointerMessage);
+                            break;
+                        case Midi.Status.Clock:
+                            Clock?.Invoke(this, new ClockMessage(message.Timestamp));
+                            break;
+                        case Midi.Status.Start:
+                            Start?.Invoke(this, new StartMessage(message.Timestamp));
+                            break;
+                        case Midi.Status.Stop:
+                            Stop?.Invoke(this, new StopMessage(message.Timestamp));
+                            break;
+                        case Midi.Status.Continue:
+                            Continue?.Invoke(this, new ContinueMessage(message.Timestamp));
+                            break;
                         default:
+                            Debug.WriteLine("Unknown system message type {Status}", $"{status:X2}");
                             Log.Error("Unknown system message type {Status}", $"{status:X2}");
                             break;
                     }
                     break;
                 
                 default:
+                    Debug.WriteLine("Unknown message type {Bitmask}", $"{status & 0b1111_0000:X2}");
                     Log.Error("Unknown message type {Bitmask}", $"{status & 0b1111_0000:X2}");
                     break;
             }
@@ -130,6 +154,11 @@ namespace RtMidi.Core.Devices
             ChannelPressure = null;
             PitchBend = null;
             SysEx = null;
+            Clock = null;
+            Start = null;
+            Stop = null;
+            Continue = null;
+            SongPositionPointer = null;
         }
 
         private void OnControlChange(in ControlChangeMessage e)

--- a/RtMidi.Core/Devices/Nrpn/NrpnInterpreter.cs
+++ b/RtMidi.Core/Devices/Nrpn/NrpnInterpreter.cs
@@ -105,7 +105,7 @@ namespace RtMidi.Core.Devices.Nrpn
 
         private void SendNrpn()
         {
-            if (NrpnMessage.TryDecode(_messages, out var msg))
+            if (NrpnMessage.TryDecode(0, _messages, out var msg))
             {
                 _onNrpn(in msg);
             }

--- a/RtMidi.Core/Messages/ChannelPressureMessage.cs
+++ b/RtMidi.Core/Messages/ChannelPressureMessage.cs
@@ -9,14 +9,24 @@ namespace RtMidi.Core.Messages
     /// This message is different from polyphonic after-touch. Use this message to send the 
     /// single greatest pressure value (of all the current depressed keys)
     /// </summary>
-    public readonly struct ChannelPressureMessage
+    public readonly struct ChannelPressureMessage: IMessage
     {
         private static readonly ILogger Log = Serilog.Log.ForContext<ChannelPressureMessage>();
 
+        public ChannelPressureMessage(double timestamp, Channel channel, int pressure)
+        {
+            StructHelper.IsWithin7BitRange(nameof(pressure), pressure);
+
+            Timestamp = timestamp;
+            Channel = channel;
+            Pressure = pressure;
+        }
+        
         public ChannelPressureMessage(Channel channel, int pressure)
         {
             StructHelper.IsWithin7BitRange(nameof(pressure), pressure);
 
+            Timestamp = 0;
             Channel = channel;
             Pressure = pressure;
         }
@@ -30,6 +40,11 @@ namespace RtMidi.Core.Messages
         /// Pressure value (0-127)
         /// </summary>
         public int Pressure { get; }
+        
+        /// <summary>
+        /// The timestamp when this message was received
+        /// </summary>
+        public double Timestamp { get; }
 
         internal byte[] Encode()
         {
@@ -40,7 +55,7 @@ namespace RtMidi.Core.Messages
             };
         }
 
-        internal static bool TryDecode(byte[] message, out ChannelPressureMessage msg)
+        internal static bool TryDecode(double timestamp, byte[] message, out ChannelPressureMessage msg)
         {
             if (message.Length != 2)
             {
@@ -51,6 +66,7 @@ namespace RtMidi.Core.Messages
 
             msg = new ChannelPressureMessage
             (
+                timestamp,
                 (Channel) (Midi.ChannelBitmask & message[0]),
                 Midi.DataBitmask & message[1]
             );
@@ -59,7 +75,7 @@ namespace RtMidi.Core.Messages
 
         public override string ToString()
         {
-            return $"{nameof(Channel)}: {Channel}, {nameof(Pressure)}: {Pressure}";
+            return $"{nameof(Timestamp)}: {Timestamp}, {nameof(Channel)}: {Channel}, {nameof(Pressure)}: {Pressure}";
         }
     }
 }

--- a/RtMidi.Core/Messages/ClockMessage.cs
+++ b/RtMidi.Core/Messages/ClockMessage.cs
@@ -1,0 +1,27 @@
+﻿namespace RtMidi.Core.Messages
+{
+    /// <summary>
+    /// Some master device that controls sequence playback sends this timing message to keep a slave device in sync
+    /// with the master. A MIDI Clock message is sent at regular intervals (based upon the master's Tempo) in order to
+    /// accomplish this.
+    ///
+    /// There are 24 MIDI Clocks in every quarter note.
+    /// </summary>
+    public readonly struct ClockMessage: IMessage
+    {
+        public ClockMessage(double timestamp)
+        {
+            Timestamp = timestamp;
+        }
+
+        /// <summary>
+        /// The timestamp when this message was received
+        /// </summary>
+        public double Timestamp { get; }
+
+        public override string ToString()
+        {
+            return $"{nameof(Timestamp)}: {Timestamp}";
+        }
+    }
+}

--- a/RtMidi.Core/Messages/ContinueMessage.cs
+++ b/RtMidi.Core/Messages/ContinueMessage.cs
@@ -1,0 +1,25 @@
+﻿namespace RtMidi.Core.Messages
+{
+    /// <summary>
+    /// Some master device that controls sequence playback sends this message to make a slave device resume playback
+    /// from its current "Song Position". The current Song Position is the point when the song/sequence was previously
+    /// stopped, or previously cued with a Song Position Pointer message.
+    /// </summary>
+    public readonly struct ContinueMessage: IMessage
+    {
+        public ContinueMessage(double timestamp)
+        {
+            Timestamp = timestamp;
+        }
+
+        /// <summary>
+        /// SysEx Data Array
+        /// </summary>
+        public double Timestamp { get; }
+
+        public override string ToString()
+        {
+            return $"{nameof(Timestamp)}: {Timestamp}";
+        }
+    }
+}

--- a/RtMidi.Core/Messages/IMessage.cs
+++ b/RtMidi.Core/Messages/IMessage.cs
@@ -1,0 +1,7 @@
+namespace RtMidi.Core.Messages
+{
+    public interface IMessage
+    {
+        double Timestamp { get; }
+    }
+}

--- a/RtMidi.Core/Messages/NRPNMessage.cs
+++ b/RtMidi.Core/Messages/NRPNMessage.cs
@@ -10,13 +10,23 @@ namespace RtMidi.Core.Messages
     /// Change messages and allows 14-bit values to be used, rather than the
     /// normal 7-bit values in regular midi messages.
     /// </summary>
-    public readonly struct NrpnMessage
+    public readonly struct NrpnMessage: IMessage
     {
         public NrpnMessage(Channel channel, int parameter, int value)
         {
             StructHelper.IsWithin14BitRange(nameof(parameter), parameter);
             StructHelper.IsWithin14BitRange(nameof(value), value);
-
+            Timestamp = 0;
+            Channel = channel;
+            Parameter = parameter;
+            Value = value;
+        }
+        
+        public NrpnMessage(double timestamp, Channel channel, int parameter, int value)
+        {
+            StructHelper.IsWithin14BitRange(nameof(parameter), parameter);
+            StructHelper.IsWithin14BitRange(nameof(value), value);
+            Timestamp = timestamp;
             Channel = channel;
             Parameter = parameter;
             Value = value;
@@ -36,6 +46,11 @@ namespace RtMidi.Core.Messages
         /// 14-bit Parameter value
         /// </summary>
         public int Value { get; }
+        
+        /// <summary>
+        /// The timestamp when this message was received
+        /// </summary>
+        public double Timestamp { get; }
 
         /// <summary>
         /// Determine if the array of Control Change messges represent a full or partial 
@@ -83,7 +98,7 @@ namespace RtMidi.Core.Messages
             };
         }
 
-        internal static bool TryDecode(ControlChangeMessage[] messages, out NrpnMessage msg)
+        internal static bool TryDecode(double timestamp, ControlChangeMessage[] messages, out NrpnMessage msg)
         {
             if (messages.Length != 4)
             {
@@ -101,6 +116,7 @@ namespace RtMidi.Core.Messages
 
             msg = new NrpnMessage
             (
+                timestamp,
                 messages[0].Channel,
                 (messages[0].Value & Midi.DataBitmask) << 7 | (messages[1].Value & Midi.DataBitmask),
                 (messages[2].Value & Midi.DataBitmask) << 7 | (messages[3].Value & Midi.DataBitmask)
@@ -110,7 +126,7 @@ namespace RtMidi.Core.Messages
 
         public override string ToString()
         {
-            return $"{nameof(Channel)}: {Channel}, {nameof(Parameter)}: {Parameter}, {nameof(Value)}: {Value}";
+            return $"{nameof(Timestamp)}: {Timestamp}, {nameof(Channel)}: {Channel}, {nameof(Parameter)}: {Parameter}, {nameof(Value)}: {Value}";
         }
     }
 }

--- a/RtMidi.Core/Messages/NoteOffMessage.cs
+++ b/RtMidi.Core/Messages/NoteOffMessage.cs
@@ -6,14 +6,23 @@ namespace RtMidi.Core.Messages
     /// <summary>
     /// This message is sent when a note is released (ended). 
     /// </summary>
-    public readonly struct NoteOffMessage
+    public readonly struct NoteOffMessage: IMessage
     {
         private static readonly ILogger Log = Serilog.Log.ForContext<NoteOffMessage>();
 
         public NoteOffMessage(Channel channel, Key key, int velocity)
         {
             StructHelper.IsWithin7BitRange(nameof(velocity), velocity);
-
+            Timestamp = 0;
+            Channel = channel;
+            Key = key;
+            Velocity = velocity;
+        }
+        
+        public NoteOffMessage(double timestamp, Channel channel, Key key, int velocity)
+        {
+            StructHelper.IsWithin7BitRange(nameof(velocity), velocity);
+            Timestamp = timestamp;
             Channel = channel;
             Key = key;
             Velocity = velocity;
@@ -33,6 +42,11 @@ namespace RtMidi.Core.Messages
         /// Velocity value (0-127)
         /// </summary>
         public int Velocity { get; }
+        
+        /// <summary>
+        /// The timestamp when this message was received
+        /// </summary>
+        public double Timestamp { get; }
 
         internal byte[] Encode()
         {
@@ -44,7 +58,7 @@ namespace RtMidi.Core.Messages
             };
         }
 
-        internal static bool TryDecode(byte[] message, out NoteOffMessage msg) 
+        internal static bool TryDecode(double timestamp, byte[] message, out NoteOffMessage msg) 
         {
             if (message.Length != 3)
             {
@@ -55,6 +69,7 @@ namespace RtMidi.Core.Messages
 
             msg = new NoteOffMessage
             (
+                timestamp,
                 (Channel) (Midi.ChannelBitmask & message[0]),
                 (Key) (Midi.DataBitmask & message[1]),
                 Midi.DataBitmask & message[2]
@@ -64,7 +79,7 @@ namespace RtMidi.Core.Messages
 
         public override string ToString()
         {
-            return $"{nameof(Channel)}: {Channel}, {nameof(Key)}: {Key}, {nameof(Velocity)}: {Velocity}";
+            return $"{nameof(Timestamp)}: {Timestamp}, {nameof(Channel)}: {Channel}, {nameof(Key)}: {Key}, {nameof(Velocity)}: {Velocity}";
         }
     }
 }

--- a/RtMidi.Core/Messages/NoteOnMessage.cs
+++ b/RtMidi.Core/Messages/NoteOnMessage.cs
@@ -6,14 +6,23 @@ namespace RtMidi.Core.Messages
     /// <summary>
     /// This message is sent when a note is depressed (start). 
     /// </summary>
-    public readonly struct NoteOnMessage
+    public readonly struct NoteOnMessage: IMessage
     {
         private static readonly ILogger Log = Serilog.Log.ForContext<NoteOnMessage>();
 
         public NoteOnMessage(Channel channel, Key key, int velocity)
         {
             StructHelper.IsWithin7BitRange(nameof(velocity), velocity);
-
+            Timestamp = 0;
+            Channel = channel;
+            Key = key;
+            Velocity = velocity;
+        }
+        
+        public NoteOnMessage(double timestamp, Channel channel, Key key, int velocity)
+        {
+            StructHelper.IsWithin7BitRange(nameof(velocity), velocity);
+            Timestamp = timestamp;
             Channel = channel;
             Key = key;
             Velocity = velocity;
@@ -33,6 +42,11 @@ namespace RtMidi.Core.Messages
         /// Velocity value (0-127)
         /// </summary>
         public int Velocity { get; }
+        
+        /// <summary>
+        /// The timestamp when this message was received
+        /// </summary>
+        public double Timestamp { get; }
 
         internal byte[] Encode()
         {
@@ -44,7 +58,7 @@ namespace RtMidi.Core.Messages
             };
         }
 
-        internal static bool TryDecode(byte[] message, out NoteOnMessage msg)
+        internal static bool TryDecode(double timestamp, byte[] message, out NoteOnMessage msg)
         {
             if (message.Length != 3)
             {
@@ -55,6 +69,7 @@ namespace RtMidi.Core.Messages
 
             msg = new NoteOnMessage
             (
+                timestamp,
                 (Channel) (Midi.ChannelBitmask & message[0]),
                 (Key) (Midi.DataBitmask & message[1]),
                 Midi.DataBitmask & message[2]
@@ -64,7 +79,7 @@ namespace RtMidi.Core.Messages
 
         public override string ToString()
         {
-            return $"{nameof(Channel)}: {Channel}, {nameof(Key)}: {Key}, {nameof(Velocity)}: {Velocity}";
+            return $"{nameof(Timestamp)}: {Timestamp}, {nameof(Channel)}: {Channel}, {nameof(Key)}: {Key}, {nameof(Velocity)}: {Velocity}";
         }
     }
 }

--- a/RtMidi.Core/Messages/PolyphonicKeyPressureMessage.cs
+++ b/RtMidi.Core/Messages/PolyphonicKeyPressureMessage.cs
@@ -6,14 +6,23 @@ namespace RtMidi.Core.Messages
     /// <summary>
     /// This message is most often sent by pressing down on the key after it "bottoms out".
     /// </summary>
-    public readonly struct PolyphonicKeyPressureMessage
+    public readonly struct PolyphonicKeyPressureMessage: IMessage
     {
         private static readonly ILogger Log = Serilog.Log.ForContext<PolyphonicKeyPressureMessage>();
 
         public PolyphonicKeyPressureMessage(Channel channel, Key key, int pressure)
         {
             StructHelper.IsWithin7BitRange(nameof(pressure), pressure);
-
+            Timestamp = 0;
+            Channel = channel;
+            Key = key;
+            Pressure = pressure;
+        }
+        
+        public PolyphonicKeyPressureMessage(double timestamp, Channel channel, Key key, int pressure)
+        {
+            StructHelper.IsWithin7BitRange(nameof(pressure), pressure);
+            Timestamp = timestamp;
             Channel = channel;
             Key = key;
             Pressure = pressure;
@@ -33,6 +42,11 @@ namespace RtMidi.Core.Messages
         /// Pressure value (0-127)
         /// </summary>
         public int Pressure { get; }
+        
+        /// <summary>
+        /// The timestamp when this message was received
+        /// </summary>
+        public double Timestamp { get; }
 
         internal byte[] Encode()
         {
@@ -44,7 +58,7 @@ namespace RtMidi.Core.Messages
             };
         }
 
-        internal static bool TryDecode(byte[] message, out PolyphonicKeyPressureMessage msg) 
+        internal static bool TryDecode(double timestamp, byte[] message, out PolyphonicKeyPressureMessage msg) 
         {
             if (message.Length != 3)
             {
@@ -55,6 +69,7 @@ namespace RtMidi.Core.Messages
 
             msg = new PolyphonicKeyPressureMessage
             (
+                timestamp,
                 (Channel) (Midi.ChannelBitmask & message[0]),
                 (Key) (Midi.DataBitmask & message[1]),
                 Midi.DataBitmask & message[2]
@@ -64,7 +79,7 @@ namespace RtMidi.Core.Messages
 
         public override string ToString()
         {
-            return $"{nameof(Channel)}: {Channel}, {nameof(Key)}: {Key}, {nameof(Pressure)}: {Pressure}";
+            return $"{nameof(Timestamp)}: {Timestamp}, {nameof(Channel)}: {Channel}, {nameof(Key)}: {Key}, {nameof(Pressure)}: {Pressure}";
         }
     }
 }

--- a/RtMidi.Core/Messages/ProgramChangeMessage.cs
+++ b/RtMidi.Core/Messages/ProgramChangeMessage.cs
@@ -7,7 +7,7 @@ namespace RtMidi.Core.Messages
     /// <summary>
     /// This message sent when the patch number changes.
     /// </summary>
-    public readonly struct ProgramChangeMessage
+    public readonly struct ProgramChangeMessage: IMessage
     {
         private static readonly ILogger Log = Serilog.Log.ForContext<ProgramChangeMessage>();
 
@@ -16,7 +16,15 @@ namespace RtMidi.Core.Messages
         public ProgramChangeMessage(Channel channel, int program)
         {
             StructHelper.IsWithin7BitRange(nameof(program), program);
-
+            Timestamp = 0;
+            Channel = channel;
+            Program = program;
+        }
+        
+        public ProgramChangeMessage(double timestamp, Channel channel, int program)
+        {
+            StructHelper.IsWithin7BitRange(nameof(program), program);
+            Timestamp = timestamp;
             Channel = channel;
             Program = program;
         }
@@ -30,6 +38,11 @@ namespace RtMidi.Core.Messages
         /// Program number (0-127)
         /// </summary>
         public int Program { get; }
+        
+        /// <summary>
+        /// The timestamp when this message was received
+        /// </summary>
+        public double Timestamp { get; }
 
         internal byte[] Encode()
         {
@@ -40,7 +53,7 @@ namespace RtMidi.Core.Messages
             };
         }
 
-        internal static bool TryDecode(byte[] message, out ProgramChangeMessage msg)
+        internal static bool TryDecode(double timestamp, byte[] message, out ProgramChangeMessage msg)
         {
             if (message.Length != 2)
             {
@@ -51,6 +64,7 @@ namespace RtMidi.Core.Messages
 
             msg = new ProgramChangeMessage
             (
+                timestamp,
                 (Channel) (Midi.ChannelBitmask & message[0]),
                 Midi.DataBitmask & message[1]
             );
@@ -59,7 +73,7 @@ namespace RtMidi.Core.Messages
 
         public override string ToString()
         {
-            return $"{nameof(Channel)}: {Channel}, {nameof(Program)}: {Program}";
+            return $"{nameof(Timestamp)}: {Timestamp}, {nameof(Channel)}: {Channel}, {nameof(Program)}: {Program}";
         }
     }
 }

--- a/RtMidi.Core/Messages/StartMessage.cs
+++ b/RtMidi.Core/Messages/StartMessage.cs
@@ -1,0 +1,24 @@
+﻿namespace RtMidi.Core.Messages
+{
+    /// <summary>
+    /// Some master device that controls sequence playback sends this message to make a slave device start playback of
+    /// some song/sequence from the beginning (ie, MIDI Beat 0).
+    /// </summary>
+    public readonly struct StartMessage: IMessage
+    {
+        public StartMessage(double timestamp)
+        {
+            Timestamp = timestamp;
+        }
+
+        /// <summary>
+        /// SysEx Data Array
+        /// </summary>
+        public double Timestamp { get; }
+
+        public override string ToString()
+        {
+            return $"{nameof(Timestamp)}: {Timestamp}";
+        }
+    }
+}

--- a/RtMidi.Core/Messages/StopMessage.cs
+++ b/RtMidi.Core/Messages/StopMessage.cs
@@ -1,0 +1,24 @@
+﻿namespace RtMidi.Core.Messages
+{
+    /// <summary>
+    /// Some master device that controls sequence playback sends this message to make a slave device stop playback of a
+    /// song/sequence.
+    /// </summary>
+    public readonly struct StopMessage: IMessage
+    {
+        public StopMessage(double timestamp)
+        {
+            Timestamp = timestamp;
+        }
+
+        /// <summary>
+        /// SysEx Data Array
+        /// </summary>
+        public double Timestamp { get; }
+
+        public override string ToString()
+        {
+            return $"{nameof(Timestamp)}: {Timestamp}";
+        }
+    }
+}

--- a/RtMidi.Core/Messages/SysExMessage.cs
+++ b/RtMidi.Core/Messages/SysExMessage.cs
@@ -6,12 +6,19 @@ namespace RtMidi.Core.Messages
     /// <summary>
     /// This message contains System Exclusive raw data sent from the device to the host.
     /// </summary>
-    public readonly struct SysExMessage
+    public readonly struct SysExMessage: IMessage
     {
         private static readonly ILogger Log = Serilog.Log.ForContext<SysExMessage>();
 
         public SysExMessage(byte[] data)
         {
+            Timestamp = 0;
+            Data = StructHelper.IsValidSysEx(data);
+        }
+        
+        public SysExMessage(double timestamp, byte[] data)
+        {
+            Timestamp = timestamp;
             Data = StructHelper.IsValidSysEx(data);
         }
 
@@ -19,13 +26,18 @@ namespace RtMidi.Core.Messages
         /// SysEx Data Array
         /// </summary>
         public byte[] Data { get; }
+        
+        /// <summary>
+        /// The timestamp when this message was received
+        /// </summary>
+        public double Timestamp { get; }
 
         internal byte[] Encode()
         {
             return StructHelper.FormatSysEx(Data);
         }
 
-        internal static bool TryDecode(byte[] message, out SysExMessage msg)
+        internal static bool TryDecode(double timestamp, byte[] message, out SysExMessage msg)
         {
             if (message.Length <= 1)
             {
@@ -43,6 +55,7 @@ namespace RtMidi.Core.Messages
 
             msg = new SysExMessage
             (
+                timestamp,
                 message
             );
             return true;
@@ -50,7 +63,7 @@ namespace RtMidi.Core.Messages
 
         public override string ToString()
         {
-            return $"{nameof(Data)}: {string.Join(", ", Data)}";
+            return $"{nameof(Timestamp)}: {Timestamp}, {nameof(Data)}: {string.Join(", ", Data)}";
         }
     }
 }

--- a/RtMidi.Core/RtMidi.Core.csproj
+++ b/RtMidi.Core/RtMidi.Core.csproj
@@ -14,6 +14,12 @@
     <PackageTags>midi netstandard netcore</PackageTags>
     <Copyright>Copyright 2017 (c) Michael Dahl. All Rights reserved.</Copyright>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
   <ItemGroup>
     <None Include="librtmidi.dylib">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/RtMidi.Core/Unmanaged/Devices/IRtMidiInputDevice.cs
+++ b/RtMidi.Core/Unmanaged/Devices/IRtMidiInputDevice.cs
@@ -9,6 +9,6 @@ namespace RtMidi.Core.Unmanaged.Devices
         /// <summary>
         /// MIDI message was received
         /// </summary>
-        event EventHandler<byte[]> Message;
+        event EventHandler<RtMidiReceivedEventArgs> Message;
     }
 }

--- a/RtMidi.Core/Unmanaged/Devices/RtMidiInputDevice.cs
+++ b/RtMidi.Core/Unmanaged/Devices/RtMidiInputDevice.cs
@@ -16,7 +16,7 @@ namespace RtMidi.Core.Unmanaged.Devices
             _rtMidiCallbackDelegate = HandleRtMidiCallback;
         }
 
-        public event EventHandler<byte[]> Message;
+        public event EventHandler<RtMidiReceivedEventArgs> Message;
 
         protected override IntPtr CreateDevice()
         {
@@ -28,7 +28,7 @@ namespace RtMidi.Core.Unmanaged.Devices
                 CheckForError(handle);
 
                 Log.Debug("Setting types to ignore");
-                RtMidiC.Input.IgnoreTypes(handle, false, true, true);
+                RtMidiC.Input.IgnoreTypes(handle, false, false, false);
                 CheckForError(handle);
 
                 Log.Debug("Setting input callback");
@@ -72,7 +72,7 @@ namespace RtMidi.Core.Unmanaged.Devices
                     Marshal.Copy(messagePtr, message, 0, size);
 
                     // Invoke message handlers
-                    messageHandlers.Invoke(this, message);
+                    messageHandlers.Invoke(this, new RtMidiReceivedEventArgs(timestamp, message));
                 }
             }
             catch (Exception e)

--- a/RtMidi.Core/Unmanaged/Devices/RtMidiReceivedEventArgs.cs
+++ b/RtMidi.Core/Unmanaged/Devices/RtMidiReceivedEventArgs.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace RtMidi.Core.Unmanaged.Devices
+{
+    public class RtMidiReceivedEventArgs: EventArgs
+    {
+        public RtMidiReceivedEventArgs(double timestamp, byte[] data)
+        {
+            Data = data;
+            Timestamp = timestamp;
+        }
+        
+        
+        public byte[] Data { get; }
+        public double Timestamp { get; }
+    }
+    
+}


### PR DESCRIPTION
This is a WIP PR related to #13 

I have added timestamp support to all events. I think the PR is backwards compatible, as it does not change the exposed callbacks. All unit tests are currently passing on Windows.

I have decided against BPM calculation in RtMidi.Core, as I think separation of concerns is appropriate here. Since the timestamp is generated by rtmidi, it doesn't matter that much if there are delays due to the event handler.